### PR TITLE
chore(dev-image): use universal developer image for tools container

### DIFF
--- a/devfile.yaml
+++ b/devfile.yaml
@@ -4,7 +4,7 @@ metadata:
 components:
   - name: tools
     container:
-      image: quay.io/eclipse/che-quarkus:next
+      image: quay.io/devfile/universal-developer-image:ubi8-d433ed6
       env:
         - name: QUARKUS_HTTP_HOST
           value: 0.0.0.0
@@ -31,7 +31,6 @@ components:
       args: ['-f', '/dev/null']
       memoryLimit: 64M
       mountSources: true
-
 
   - name: m2
     volume:
@@ -62,7 +61,6 @@ commands:
       group:
         kind: run
         isDefault: true
-
   - id: startnative
     exec:
       label: "Start Native"


### PR DESCRIPTION
Signed-off-by: Vitaliy Gulyy <vgulyy@redhat.com>

Uses [latest tag of universal developer image](https://quay.io/repository/devfile/universal-developer-image?tab=tags&tag=ubi8-d433ed6) for tooling container.

Solves https://github.com/eclipse/che/issues/20657


**Check list**:

Your pull request:

- [ ] targets the `development` branch
- [ ] uses the `999-SNAPSHOT` version of Quarkus
- [ ] has tests (`mvn clean test`)
- [ ] works in native (`mvn clean package -Pnative`)
- [ ] has native tests (`mvn clean verify -Pnative`)
- [ ] makes sure the associated guide must not be updated
- [ ] links the guide update pull request (if needed)
- [ ] updates or creates the `README.md` file (with build and run instructions)
- [ ] for new quickstart, is located in the directory _component-quickstart_
- [ ] for new quickstart, is added to the root `pom.xml` and `README.md`


