### PR TITLE
chore: use PROJECT_SOURCE instead of PROJECTS_ROOT

### DIFF
--- a/devfile.yaml
+++ b/devfile.yaml
@@ -4,7 +4,7 @@ metadata:
 components:
   - name: tools
     container:
-      image: quay.io/devfile/universal-developer-image:ubi8-d433ed6
+      image: quay.io/devfile/universal-developer-image:ubi8-0e189d9
       env:
         - name: QUARKUS_HTTP_HOST
           value: 0.0.0.0
@@ -35,37 +35,41 @@ components:
   - name: m2
     volume:
       size: 1G
+
 commands:
   - id: package
     exec:
       component: tools
-      workingDir: ${PROJECTS_ROOT}/quarkus-quickstarts/getting-started
+      workingDir: ${PROJECT_SOURCE}/getting-started
       commandLine: "./mvnw package"
       group:
         kind: build
         isDefault: true
-  - id: packagenative
+
+  - id: package-native
     exec:
       label: "Package Native"
       component: tools
-      workingDir: ${PROJECTS_ROOT}/quarkus-quickstarts/getting-started
+      workingDir: ${PROJECT_SOURCE}/getting-started
       commandLine: "./mvnw package -Dnative -Dmaven.test.skip -Dquarkus.native.native-image-xmx=2G"
       group:
         kind: build
-  - id: startdev
+
+  - id: start-dev
     exec:
       label: "Start Development mode (Hot reload + debug)"
       component: tools
-      workingDir: ${PROJECTS_ROOT}/quarkus-quickstarts/getting-started
+      workingDir: ${PROJECT_SOURCE}/getting-started
       commandLine: "./mvnw compile quarkus:dev"
       group:
         kind: run
         isDefault: true
-  - id: startnative
+
+  - id: start-native
     exec:
       label: "Start Native"
       component: ubi-minimal
-      workingDir: ${PROJECTS_ROOT}/quarkus-quickstarts/getting-started/target
+      workingDir: ${PROJECT_SOURCE}/getting-started/target
       commandLine: "./getting-started-1.0.0-SNAPSHOT-runner"
       group:
         kind: run


### PR DESCRIPTION
Signed-off-by: Vitaliy Gulyy <vgulyy@redhat.com>

- Replaces PROJECTS_ROOT environment variable on PROJECT_SOURCE in devfile commands
- Bumps to the latest tag of universal developer image

**Check list**:

Your pull request:

- [ ] targets the `development` branch
- [ ] uses the `999-SNAPSHOT` version of Quarkus
- [ ] has tests (`mvn clean test`)
- [ ] works in native (`mvn clean package -Pnative`)
- [ ] has native tests (`mvn clean verify -Pnative`)
- [ ] makes sure the associated guide must not be updated
- [ ] links the guide update pull request (if needed)
- [ ] updates or creates the `README.md` file (with build and run instructions)
- [ ] for new quickstart, is located in the directory _component-quickstart_
- [ ] for new quickstart, is added to the root `pom.xml` and `README.md`


