### PR TITLE
chore: update UDI

### DIFF
--- a/devfile.yaml
+++ b/devfile.yaml
@@ -4,7 +4,7 @@ metadata:
 components:
   - name: tools
     container:
-      image: quay.io/devfile/universal-developer-image:ubi8-0e189d9
+      image: quay.io/devfile/universal-developer-image:ubi8-3055e6d
       env:
         - name: QUARKUS_HTTP_HOST
           value: 0.0.0.0

--- a/devfile.yaml
+++ b/devfile.yaml
@@ -21,7 +21,7 @@ components:
       volumeMounts:
         - name: m2
           path: /home/user/.m2
-      memoryLimit: 4G
+      memoryLimit: 4.7G
       mountSources: true
 
   - name: ubi-minimal
@@ -41,7 +41,7 @@ commands:
     exec:
       component: tools
       workingDir: ${PROJECT_SOURCE}/getting-started
-      commandLine: "./mvnw package"
+      commandLine: "mvn package"
       group:
         kind: build
         isDefault: true
@@ -51,7 +51,7 @@ commands:
       label: "Package Native"
       component: tools
       workingDir: ${PROJECT_SOURCE}/getting-started
-      commandLine: "./mvnw package -Dnative -Dmaven.test.skip -Dquarkus.native.native-image-xmx=2G"
+      commandLine: "mvn package -Dnative -Dmaven.test.skip -Dquarkus.native.native-image-xmx=2G"
       group:
         kind: build
 
@@ -60,7 +60,7 @@ commands:
       label: "Start Development mode (Hot reload + debug)"
       component: tools
       workingDir: ${PROJECT_SOURCE}/getting-started
-      commandLine: "./mvnw compile quarkus:dev"
+      commandLine: "mvn compile quarkus:dev"
       group:
         kind: run
         isDefault: true


### PR DESCRIPTION
Signed-off-by: svor <vsvydenk@redhat.com>

- Update UDI to provide support for the native package 
- Use **mvn** instead of **mvnw**
- Increase memory for tools container

**DEPENDS ON** https://github.com/che-samples/quarkus-quickstarts/pull/6
Related issue: https://github.com/eclipse/che/issues/21145

![screenshot-che-dogfooding apps che-dev x6e0 p1 openshiftapps com-2022 06 06-16_39_42](https://user-images.githubusercontent.com/1271546/172381940-c17b4bbe-7f92-4674-81ba-f58f5db448d3.png)

![Screenshot from 2022-06-08 12-38-55](https://user-images.githubusercontent.com/1271546/172591346-24c76bd3-928b-4bec-a864-98848df2f359.png)


