### PR TITLE
chore: add missing java extensions to .vscode/extensions.json

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -2,6 +2,10 @@
   // See https://go.microsoft.com/fwlink/?LinkId=827846
   // for the documentation about the extensions.json format
   "recommendations": [
-    "redhat.vscode-quarkus"
+    "redhat.vscode-quarkus",
+    "redhat.java",
+    "redhat.vscode-microprofile",
+    "vscjava.vscode-java-debug",
+    "vscjava.vscode-java-test"
   ]
 }


### PR DESCRIPTION
Signed-off-by: Vitaliy Gulyy <vgulyy@redhat.com>

At the moment, `.vscode/recommendations.json` contains only one `redhat.vscode-quarkus`.

[A plugin definition in che-plugin-registry](https://eclipse-che.github.io/che-plugin-registry/main/v3/plugins/redhat/vscode-quarkus/latest/che-theia-plugin.yaml) for `redhat.vscode-quarkus` describes some set of dependencies.

But when creating a workspace, these dependencies are not installed as che-code does know anything about che-plugin-registry.

The idea is to add that plugins to recommendations directly.

Solves https://github.com/eclipse/che/issues/21644