### PR TITLE
devfile:use https protocol in endpoint

### DIFF
--- a/devfile.yaml
+++ b/devfile.yaml
@@ -15,7 +15,7 @@ components:
           targetPort: 5005
         - exposure: public
           name: hello-greeting-endpoint
-          protocol: http
+          protocol: https
           targetPort: 8080
           path: /hello/greeting/che-user
       volumeMounts:


### PR DESCRIPTION
devfile:use https protocol in endpoint

![screenshot-che-dogfooding apps che-dev x6e0 p1 openshiftapps com-2023 12 21-13_01_19](https://github.com/che-samples/quarkus-quickstarts/assets/1271546/77d6fe25-f628-41a5-acc2-5abfe466b0ef)


Related issue: https://issues.redhat.com/browse/CRW-5377