### PR TITLE
set devfile schemaVersion 2.2.2

### DIFF
--- a/devfile.yaml
+++ b/devfile.yaml
@@ -14,7 +14,7 @@ components:
           protocol: tcp
           targetPort: 5005
         - exposure: public
-          name: hello-greeting-endpoint
+          name: hello-greeting
           protocol: https
           targetPort: 8080
           path: /hello/greeting/che-user

--- a/devfile.yaml
+++ b/devfile.yaml
@@ -1,4 +1,4 @@
-schemaVersion: 2.1.0
+schemaVersion: 2.2.2
 metadata:
   name: quarkus-quickstart
 components:


### PR DESCRIPTION
Set devfile schemaVersion: 2.2.2

![screenshot-che-dogfooding apps che-dev x6e0 p1 openshiftapps com-2024 01 31-17_02_43](https://github.com/che-samples/quarkus-quickstarts/assets/1271546/c537b468-af47-4496-b61e-e80497d7c734)

Related issue: https://github.com/eclipse/che/issues/21985

